### PR TITLE
Display warning when opening non-repository folder

### DIFF
--- a/Offbeat.GitWorkbench/RepositoryManagement/GitRepositoryView.xaml
+++ b/Offbeat.GitWorkbench/RepositoryManagement/GitRepositoryView.xaml
@@ -39,11 +39,17 @@
 				<RowDefinition Height="*"></RowDefinition>
 			</Grid.RowDefinitions>
 
+			<StackPanel Grid.Row="0" Orientation="Vertical" 
+					HorizontalAlignment="Center" 
+					VerticalAlignment="Center"
+					Visibility="{Binding NotRepository, Converter={StaticResource BooleanToVisibility}}">
+				<TextBlock FontSize="20">The folder does not contain a valid Git repository</TextBlock>
+			</StackPanel>
 			<ListView Grid.Row="0" 
 					  x:Name="RevisionList"
 					  ItemsSource="{Binding Source={StaticResource VisibleRevisions}}" 
 					  SelectedItem="{Binding SelectedRevision}"
-					  Visibility="{Binding Loading, Converter={StaticResource NegateVisibility}, FallbackValue=False}">
+					  Visibility="{Binding LoadedValidRepository, Converter={StaticResource BooleanToVisibility}}">
 				<ListView.View>
 					<GridView>
 						<GridViewColumn Header="Graph">

--- a/Offbeat.GitWorkbench/RepositoryManagement/GitRepositoryViewModel.cs
+++ b/Offbeat.GitWorkbench/RepositoryManagement/GitRepositoryViewModel.cs
@@ -18,6 +18,7 @@ namespace Offbeat.GitWorkbench.RepositoryManagement
 		private static ILogger logger = LogManager.GetCurrentClassLogger();
 		public string Path { get; }
 		private bool loading;
+		private bool notRepository;
 		private ICommitLogEntryViewModel selectedRevision;
 		private double? detailsViewHeight;
 		private IRepositoryView view;
@@ -40,8 +41,26 @@ namespace Offbeat.GitWorkbench.RepositoryManagement
 				}
 				loading = value;
 				NotifyOfPropertyChange();
+				NotifyOfPropertyChange(nameof(LoadedValidRepository));
 			}
 		}
+
+		public bool NotRepository {
+			get {
+				return notRepository;
+			}
+			set {
+				if (value == notRepository)
+				{
+					return;
+				}
+				notRepository = value;
+				NotifyOfPropertyChange();
+				NotifyOfPropertyChange(nameof(LoadedValidRepository));
+			}
+		}
+
+		public bool LoadedValidRepository => !NotRepository && !Loading;
 
 		protected override void OnViewAttached(object view, object context) {
 			base.OnViewAttached(view, context);
@@ -76,6 +95,11 @@ namespace Offbeat.GitWorkbench.RepositoryManagement
 			if (Repository != null) {
 				await LoadCommitsAsync();
 
+				Loading = false;
+			}
+			else
+			{
+				NotRepository = true;
 				Loading = false;
 			}
 


### PR DESCRIPTION
I was a little confused when I accidently opened a folder that was not a repository, and it just showed the loading bar, without never stopping. I thought there is a problem with the repository, but it was just that there was no warning when opening something that is not a repository. While maybe it should refure to open it altogether, I thought it should still show this to the user, in case someones removes a repo and then offgit starts and shows the recently opened ones. 